### PR TITLE
Update to new PTC template

### DIFF
--- a/.github/ISSUE_TEMPLATE/card-submission.md
+++ b/.github/ISSUE_TEMPLATE/card-submission.md
@@ -3,7 +3,7 @@ name: Card Submission
 about: This is a template for contributor's to submit progress tracking cards of their
   own via GitHub Issues.
 title: PTC Recommendation
-labels: ''
+labels: 'new ptc'
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/card-submission.md
+++ b/.github/ISSUE_TEMPLATE/card-submission.md
@@ -13,20 +13,19 @@ assignees: ''
 > Suggest a short **name** that covers the topic of your card (like *UnitTesting*). 
 > Then provide a brief description of the the goal (**target**) that a user is trying to reach with this card.
 
-<!-- Your Description Below -->
+**Target**: <!-- Your Description Here -->
 
-# User Stories
 > Next, provide one or more **user stories** that explain the context of this goal.
 > A user story is a statement that can be phrased as "As a _____, I want _____ so that _____."
 
-<!-- Your User Story Below -->
+**User Story**: As a  <!-- FILL IN --> , I want <!-- FILL IN -->, so that <!-- FILL IN -->.
 
-# Card(s)
+## Card(s)
 
 > Provide one or more cards to help a prospective user measure progress towards the goal (such as adopting a new practice or technology). A progress tracking card consists of a numbered list, where the numbers represent a set of scores (often from zero to five), and each item in the list is a qualitative description that illustrates what it means to reach that score. Zero should represent a starting state, and the highest number should represent fully achieving the goal.
 
 <!--
-Your Card Below.
+Your Card Here.
 Example:
 0. Little or no independent testing. Functional testing via users.
 1. Independent functional testing of primary capabilities.
@@ -36,10 +35,15 @@ Example:
 5. Comprehensive unit, use case functional testing; test coverage commitment.
 -->
 
-# Comments
+## Comments
 > Here you may add any additional comments to help the reader use your item in the catalog, such as definitions or links to helpful material.
 
-<!-- Any Comments Below -->
+<!-- Any Comments Here -->
+
+## Related Cards
+> If you know of any existing cards which relate to this card (or would like to suggest cards that should be created), list them here.
+
+<!-- Related Cards Here -->
 
 # Other Remarks
 


### PR DESCRIPTION
includes a place to list related cards.

After going through the process a few times, I'd like to change the format slightly. 

Eventually, I think we'll need a linter/static checker to make sure cards are in a uniform format and can be processed by a script to generate both the checklist & table versions.