### PR TITLE
Add metadata tag and acknowledgement to PTCs

### DIFF
--- a/catalog/AdoptAutomatedCorrectnessTestingInLegacySoftwareProject.md
+++ b/catalog/AdoptAutomatedCorrectnessTestingInLegacySoftwareProject.md
@@ -35,4 +35,4 @@ As a developer on a legacy software project/product, I want my team to adopt inc
 
 ### Acknowledgement
 
-This project tracking card was created using the [BSSw PSIP Project Tracking Card Catalog](https://bssw-psip.github.io/ptc-catalog/), part of the Exascale Computing Project (ECP).
+This Project Tracking Card originated from the [PSIP PTC Catalog](https://bssw-psip.github.io/ptc-catalog/). The development of the PSIP PTC Catalog was supported by the Exascale Computing Project (17-SC-20-SC), a collaborative effort of the U.S. Department of Energy Office of Science and the National Nuclear Security Administration.

--- a/catalog/AdoptAutomatedCorrectnessTestingInLegacySoftwareProject.md
+++ b/catalog/AdoptAutomatedCorrectnessTestingInLegacySoftwareProject.md
@@ -1,4 +1,4 @@
-[metadata:tags]:- "ecp-psip-ptc"
+[metadata:tags]:- "bssw-psip-ptc"
 # Adopt Automated Correctness Testing in a Legacy Software Project
 
 ## Target

--- a/catalog/AdoptAutomatedCorrectnessTestingInLegacySoftwareProject.md
+++ b/catalog/AdoptAutomatedCorrectnessTestingInLegacySoftwareProject.md
@@ -1,4 +1,4 @@
-[_metadata_:tags]:- "psip-ptc"
+[_metadata_:tags]:- "ecp-psip-ptc"
 # Adopt Automated Correctness Testing in a Legacy Software Project
 
 ## Target

--- a/catalog/AdoptAutomatedCorrectnessTestingInLegacySoftwareProject.md
+++ b/catalog/AdoptAutomatedCorrectnessTestingInLegacySoftwareProject.md
@@ -1,4 +1,4 @@
-[_metadata_:tags]:- "ecp-psip-ptc"
+[metadata:tags]:- "ecp-psip-ptc"
 # Adopt Automated Correctness Testing in a Legacy Software Project
 
 ## Target
@@ -31,3 +31,8 @@ As a developer on a legacy software project/product, I want my team to adopt inc
 * The PTC [Continuous Integration](https://github.com/bssw-psip/ptc-catalog/blob/master/catalog/ContinuousIntegration.md) describes steps/levels in how to take an existing set of automated tests and how run them, how to display their results, and how to use them to gate different development, integration, and other processes.
 * The PTC [Test Coverage](https://github.com/bssw-psip/ptc-catalog/blob/master/catalog/TestCoverage.md) is similar to this PTC except this PTC is consistent with advice in the book ["Working Effectively with Legacy Code"](https://bssw.io/items/working-effectively-with-legacy-code) by Robert Martin in that it does not expect that detailed unit tests will be added to cover all of the existing legacy code and that is okay.
 * The PTC [Test Driven Development](https://github.com/bssw-psip/ptc-catalog/blob/master/catalog/TestDrivenDevelopment.md) describes the phased introduction on test driven development and would seem to mostly apply to new code that is being written but does not address changes to existing code.
+
+
+### Acknowledgement
+
+This project tracking card was created using the [BSSw PSIP Project Tracking Card Catalog](https://bssw-psip.github.io/ptc-catalog/), part of the Exascale Computing Project (ECP).

--- a/catalog/AdoptAutomatedCorrectnessTestingInLegacySoftwareProject.md
+++ b/catalog/AdoptAutomatedCorrectnessTestingInLegacySoftwareProject.md
@@ -1,3 +1,4 @@
+[_metadata_:tags]:- "psip-ptc"
 # Adopt Automated Correctness Testing in a Legacy Software Project
 
 ## Target

--- a/catalog/AgileAdoption.md
+++ b/catalog/AgileAdoption.md
@@ -1,3 +1,4 @@
+[_metadata_:tags]:- "psip-ptc"
 # Agile Adoption
 
 ## Target

--- a/catalog/AgileAdoption.md
+++ b/catalog/AgileAdoption.md
@@ -1,4 +1,4 @@
-[metadata:tags]:- "ecp-psip-ptc"
+[metadata:tags]:- "bssw-psip-ptc"
 # Agile Adoption
 
 ## Target

--- a/catalog/AgileAdoption.md
+++ b/catalog/AgileAdoption.md
@@ -28,4 +28,4 @@ As a project leader, I have heard of teams that have adopted Agile workflows and
 
 ### Acknowledgement
 
-This project tracking card was created using the [BSSw PSIP Project Tracking Card Catalog](https://bssw-psip.github.io/ptc-catalog/), part of the Exascale Computing Project (ECP).
+This Project Tracking Card originated from the [PSIP PTC Catalog](https://bssw-psip.github.io/ptc-catalog/). The development of the PSIP PTC Catalog was supported by the Exascale Computing Project (17-SC-20-SC), a collaborative effort of the U.S. Department of Energy Office of Science and the National Nuclear Security Administration.

--- a/catalog/AgileAdoption.md
+++ b/catalog/AgileAdoption.md
@@ -1,4 +1,4 @@
-[_metadata_:tags]:- "psip-ptc"
+[_metadata_:tags]:- "ecp-psip-ptc"
 # Agile Adoption
 
 ## Target

--- a/catalog/AgileAdoption.md
+++ b/catalog/AgileAdoption.md
@@ -1,4 +1,4 @@
-[_metadata_:tags]:- "ecp-psip-ptc"
+[metadata:tags]:- "ecp-psip-ptc"
 # Agile Adoption
 
 ## Target
@@ -24,3 +24,8 @@ As a project leader, I have heard of teams that have adopted Agile workflows and
 ## Comments
 
 1. Examples of Agile processes include stand-up meetings, additional Kanban board columns, user stories, epic/story/task work breakdowns, etc.
+
+
+### Acknowledgement
+
+This project tracking card was created using the [BSSw PSIP Project Tracking Card Catalog](https://bssw-psip.github.io/ptc-catalog/), part of the Exascale Computing Project (ECP).

--- a/catalog/AlgorithmProductization.md
+++ b/catalog/AlgorithmProductization.md
@@ -1,3 +1,4 @@
+[_metadata_:tags]:- "psip-ptc"
 # Algorithm Productization Checklist
 
 ## Target

--- a/catalog/AlgorithmProductization.md
+++ b/catalog/AlgorithmProductization.md
@@ -1,4 +1,4 @@
-[metadata:tags]:- "ecp-psip-ptc"
+[metadata:tags]:- "bssw-psip-ptc"
 # Algorithm Productization Checklist
 
 ## Target

--- a/catalog/AlgorithmProductization.md
+++ b/catalog/AlgorithmProductization.md
@@ -34,4 +34,4 @@ As an algorithm developer, I want to develop and productize an ECP-relevant algo
 
 ### Acknowledgement
 
-This project tracking card was created using the [BSSw PSIP Project Tracking Card Catalog](https://bssw-psip.github.io/ptc-catalog/), part of the Exascale Computing Project (ECP).
+This Project Tracking Card originated from the [PSIP PTC Catalog](https://bssw-psip.github.io/ptc-catalog/). The development of the PSIP PTC Catalog was supported by the Exascale Computing Project (17-SC-20-SC), a collaborative effort of the U.S. Department of Energy Office of Science and the National Nuclear Security Administration.

--- a/catalog/AlgorithmProductization.md
+++ b/catalog/AlgorithmProductization.md
@@ -1,4 +1,4 @@
-[_metadata_:tags]:- "ecp-psip-ptc"
+[metadata:tags]:- "ecp-psip-ptc"
 # Algorithm Productization Checklist
 
 ## Target
@@ -30,3 +30,8 @@ As an algorithm developer, I want to develop and productize an ECP-relevant algo
 
 - Some algorithms may go through a phase with both VTK-h and VTK-m code
 - Development of VTK-m filters must adhere to the [VTK-m contributing guide](https://gitlab.kitware.com/vtk/vtk-m/blob/master/CONTRIBUTING.md)
+
+
+### Acknowledgement
+
+This project tracking card was created using the [BSSw PSIP Project Tracking Card Catalog](https://bssw-psip.github.io/ptc-catalog/), part of the Exascale Computing Project (ECP).

--- a/catalog/AlgorithmProductization.md
+++ b/catalog/AlgorithmProductization.md
@@ -1,4 +1,4 @@
-[_metadata_:tags]:- "psip-ptc"
+[_metadata_:tags]:- "ecp-psip-ptc"
 # Algorithm Productization Checklist
 
 ## Target

--- a/catalog/CodingStandards.md
+++ b/catalog/CodingStandards.md
@@ -1,4 +1,4 @@
-[metadata:tags]:- "ecp-psip-ptc"
+[metadata:tags]:- "bssw-psip-ptc"
 # Adopting Consistent Coding Standards
 
 ## Target

--- a/catalog/CodingStandards.md
+++ b/catalog/CodingStandards.md
@@ -1,4 +1,4 @@
-[_metadata_:tags]:- "psip-ptc"
+[_metadata_:tags]:- "ecp-psip-ptc"
 # Adopting Consistent Coding Standards
 
 ## Target

--- a/catalog/CodingStandards.md
+++ b/catalog/CodingStandards.md
@@ -1,4 +1,4 @@
-[_metadata_:tags]:- "ecp-psip-ptc"
+[metadata:tags]:- "ecp-psip-ptc"
 # Adopting Consistent Coding Standards
 
 ## Target
@@ -37,3 +37,8 @@ As a software developer on a project that has a defined coding standard, I want 
 ## Comments
 
 Percentages used in Variant B may reflect number of lines in the code, team expertise for understanding and documenting code, timeline for this PTC and several other factors. When the team considers a task completed in the last step will vary from team to team.
+
+
+### Acknowledgement
+
+This project tracking card was created using the [BSSw PSIP Project Tracking Card Catalog](https://bssw-psip.github.io/ptc-catalog/), part of the Exascale Computing Project (ECP).

--- a/catalog/CodingStandards.md
+++ b/catalog/CodingStandards.md
@@ -1,3 +1,4 @@
+[_metadata_:tags]:- "psip-ptc"
 # Adopting Consistent Coding Standards
 
 ## Target

--- a/catalog/CodingStandards.md
+++ b/catalog/CodingStandards.md
@@ -41,4 +41,4 @@ Percentages used in Variant B may reflect number of lines in the code, team expe
 
 ### Acknowledgement
 
-This project tracking card was created using the [BSSw PSIP Project Tracking Card Catalog](https://bssw-psip.github.io/ptc-catalog/), part of the Exascale Computing Project (ECP).
+This Project Tracking Card originated from the [PSIP PTC Catalog](https://bssw-psip.github.io/ptc-catalog/). The development of the PSIP PTC Catalog was supported by the Exascale Computing Project (17-SC-20-SC), a collaborative effort of the U.S. Department of Energy Office of Science and the National Nuclear Security Administration.

--- a/catalog/CommunityBuilding.md
+++ b/catalog/CommunityBuilding.md
@@ -1,4 +1,4 @@
-[_metadata_:tags]:- "ecp-psip-ptc"
+[metadata:tags]:- "ecp-psip-ptc"
 # Build a Local Community of Practice
 
 ## Target
@@ -24,3 +24,8 @@ As an individual software contributor I want to build a community so that I can 
 ## Comments
 
 1. [Building Connections and Community within an Institution](https://bssw.io/blog_posts/building-connections-and-community-within-an-institution)
+
+
+### Acknowledgement
+
+This project tracking card was created using the [BSSw PSIP Project Tracking Card Catalog](https://bssw-psip.github.io/ptc-catalog/), part of the Exascale Computing Project (ECP).

--- a/catalog/CommunityBuilding.md
+++ b/catalog/CommunityBuilding.md
@@ -28,4 +28,4 @@ As an individual software contributor I want to build a community so that I can 
 
 ### Acknowledgement
 
-This project tracking card was created using the [BSSw PSIP Project Tracking Card Catalog](https://bssw-psip.github.io/ptc-catalog/), part of the Exascale Computing Project (ECP).
+This Project Tracking Card originated from the [PSIP PTC Catalog](https://bssw-psip.github.io/ptc-catalog/). The development of the PSIP PTC Catalog was supported by the Exascale Computing Project (17-SC-20-SC), a collaborative effort of the U.S. Department of Energy Office of Science and the National Nuclear Security Administration.

--- a/catalog/CommunityBuilding.md
+++ b/catalog/CommunityBuilding.md
@@ -1,4 +1,4 @@
-[metadata:tags]:- "ecp-psip-ptc"
+[metadata:tags]:- "bssw-psip-ptc"
 # Build a Local Community of Practice
 
 ## Target

--- a/catalog/CommunityBuilding.md
+++ b/catalog/CommunityBuilding.md
@@ -1,3 +1,4 @@
+[_metadata_:tags]:- "psip-ptc"
 # Build a Local Community of Practice
 
 ## Target

--- a/catalog/CommunityBuilding.md
+++ b/catalog/CommunityBuilding.md
@@ -1,4 +1,4 @@
-[_metadata_:tags]:- "psip-ptc"
+[_metadata_:tags]:- "ecp-psip-ptc"
 # Build a Local Community of Practice
 
 ## Target

--- a/catalog/ContinuousIntegration.md
+++ b/catalog/ContinuousIntegration.md
@@ -38,4 +38,4 @@ As a person responsible for software quality and correctness for my project, I w
 
 ### Acknowledgement
 
-This project tracking card was created using the [BSSw PSIP Project Tracking Card Catalog](https://bssw-psip.github.io/ptc-catalog/), part of the Exascale Computing Project (ECP).
+This Project Tracking Card originated from the [PSIP PTC Catalog](https://bssw-psip.github.io/ptc-catalog/). The development of the PSIP PTC Catalog was supported by the Exascale Computing Project (17-SC-20-SC), a collaborative effort of the U.S. Department of Energy Office of Science and the National Nuclear Security Administration.

--- a/catalog/ContinuousIntegration.md
+++ b/catalog/ContinuousIntegration.md
@@ -1,4 +1,4 @@
-[metadata:tags]:- "ecp-psip-ptc"
+[metadata:tags]:- "bssw-psip-ptc"
 # Continuous Integration
 
 ## Target

--- a/catalog/ContinuousIntegration.md
+++ b/catalog/ContinuousIntegration.md
@@ -1,4 +1,4 @@
-[_metadata_:tags]:- "psip-ptc"
+[_metadata_:tags]:- "ecp-psip-ptc"
 # Continuous Integration
 
 ## Target

--- a/catalog/ContinuousIntegration.md
+++ b/catalog/ContinuousIntegration.md
@@ -1,3 +1,4 @@
+[_metadata_:tags]:- "psip-ptc"
 # Continuous Integration
 
 ## Target

--- a/catalog/ContinuousIntegration.md
+++ b/catalog/ContinuousIntegration.md
@@ -1,4 +1,4 @@
-[_metadata_:tags]:- "ecp-psip-ptc"
+[metadata:tags]:- "ecp-psip-ptc"
 # Continuous Integration
 
 ## Target
@@ -34,3 +34,8 @@ As a person responsible for software quality and correctness for my project, I w
 | 5 | Team establishes policy to bypass required testing in the rare cases it is appropriate. |
 
 ## Comments
+
+
+### Acknowledgement
+
+This project tracking card was created using the [BSSw PSIP Project Tracking Card Catalog](https://bssw-psip.github.io/ptc-catalog/), part of the Exascale Computing Project (ECP).

--- a/catalog/CreatingCommunityPolicies.md
+++ b/catalog/CreatingCommunityPolicies.md
@@ -1,3 +1,4 @@
+[_metadata_:tags]:- "psip-ptc"
 # Creating Community Policies
 
 ## Target

--- a/catalog/CreatingCommunityPolicies.md
+++ b/catalog/CreatingCommunityPolicies.md
@@ -1,4 +1,4 @@
-[metadata:tags]:- "ecp-psip-ptc"
+[metadata:tags]:- "bssw-psip-ptc"
 # Creating Community Policies
 
 ## Target

--- a/catalog/CreatingCommunityPolicies.md
+++ b/catalog/CreatingCommunityPolicies.md
@@ -1,4 +1,4 @@
-[_metadata_:tags]:- "psip-ptc"
+[_metadata_:tags]:- "ecp-psip-ptc"
 # Creating Community Policies
 
 ## Target

--- a/catalog/CreatingCommunityPolicies.md
+++ b/catalog/CreatingCommunityPolicies.md
@@ -30,4 +30,4 @@ As a developer of a software library, I want to collaborate with others to estab
 
 ### Acknowledgement
 
-This project tracking card was created using the [BSSw PSIP Project Tracking Card Catalog](https://bssw-psip.github.io/ptc-catalog/), part of the Exascale Computing Project (ECP).
+This Project Tracking Card originated from the [PSIP PTC Catalog](https://bssw-psip.github.io/ptc-catalog/). The development of the PSIP PTC Catalog was supported by the Exascale Computing Project (17-SC-20-SC), a collaborative effort of the U.S. Department of Energy Office of Science and the National Nuclear Security Administration.

--- a/catalog/CreatingCommunityPolicies.md
+++ b/catalog/CreatingCommunityPolicies.md
@@ -1,4 +1,4 @@
-[_metadata_:tags]:- "ecp-psip-ptc"
+[metadata:tags]:- "ecp-psip-ptc"
 # Creating Community Policies
 
 ## Target
@@ -26,3 +26,8 @@ As a developer of a software library, I want to collaborate with others to estab
 
 - This card was inspired by the BSSw.io article [What are Interoperable Software Libraries? Introducing the xSDK](https://bssw.io/items/what-are-interoperable-software-libraries-introducing-the-xsdk)
 - Once this card is completed, teams are encouraged to loop back to step 2 for further revisions; also possibly pursue a related topic: coordinated release of software packages that are compatible with community software policies |
+
+
+### Acknowledgement
+
+This project tracking card was created using the [BSSw PSIP Project Tracking Card Catalog](https://bssw-psip.github.io/ptc-catalog/), part of the Exascale Computing Project (ECP).

--- a/catalog/DeveloperDocumentation.md
+++ b/catalog/DeveloperDocumentation.md
@@ -38,4 +38,4 @@
 
 ### Acknowledgement
 
-This project tracking card was created using the [BSSw PSIP Project Tracking Card Catalog](https://bssw-psip.github.io/ptc-catalog/), part of the Exascale Computing Project (ECP).
+This Project Tracking Card originated from the [PSIP PTC Catalog](https://bssw-psip.github.io/ptc-catalog/). The development of the PSIP PTC Catalog was supported by the Exascale Computing Project (17-SC-20-SC), a collaborative effort of the U.S. Department of Energy Office of Science and the National Nuclear Security Administration.

--- a/catalog/DeveloperDocumentation.md
+++ b/catalog/DeveloperDocumentation.md
@@ -1,4 +1,4 @@
-[_metadata_:tags]:- "psip-ptc"
+[_metadata_:tags]:- "ecp-psip-ptc"
 # Developer Documentation
 
  ## Target

--- a/catalog/DeveloperDocumentation.md
+++ b/catalog/DeveloperDocumentation.md
@@ -1,4 +1,4 @@
-[_metadata_:tags]:- "ecp-psip-ptc"
+[metadata:tags]:- "ecp-psip-ptc"
 # Developer Documentation
 
  ## Target
@@ -34,3 +34,8 @@
     - [ReadTheDocs](https://readthedocs.org)
     - [WriteTheDocs](https://www.writethedocs.org)
     
+
+
+### Acknowledgement
+
+This project tracking card was created using the [BSSw PSIP Project Tracking Card Catalog](https://bssw-psip.github.io/ptc-catalog/), part of the Exascale Computing Project (ECP).

--- a/catalog/DeveloperDocumentation.md
+++ b/catalog/DeveloperDocumentation.md
@@ -1,3 +1,4 @@
+[_metadata_:tags]:- "psip-ptc"
 # Developer Documentation
 
  ## Target

--- a/catalog/DeveloperDocumentation.md
+++ b/catalog/DeveloperDocumentation.md
@@ -1,4 +1,4 @@
-[metadata:tags]:- "ecp-psip-ptc"
+[metadata:tags]:- "bssw-psip-ptc"
 # Developer Documentation
 
  ## Target

--- a/catalog/EpicsForTracking.md
+++ b/catalog/EpicsForTracking.md
@@ -1,4 +1,4 @@
-[_metadata_:tags]:- "psip-ptc"
+[_metadata_:tags]:- "ecp-psip-ptc"
 # Using Epics in Jira for Tracking and Collaboration
 
 ## Target

--- a/catalog/EpicsForTracking.md
+++ b/catalog/EpicsForTracking.md
@@ -1,3 +1,4 @@
+[_metadata_:tags]:- "psip-ptc"
 # Using Epics in Jira for Tracking and Collaboration
 
 ## Target

--- a/catalog/EpicsForTracking.md
+++ b/catalog/EpicsForTracking.md
@@ -1,4 +1,4 @@
-[_metadata_:tags]:- "ecp-psip-ptc"
+[metadata:tags]:- "ecp-psip-ptc"
 # Using Epics in Jira for Tracking and Collaboration
 
 ## Target
@@ -23,3 +23,8 @@ As a project manager I want all staff to write Jira Epics representing LOE so th
 
 ## Comments
 
+
+
+### Acknowledgement
+
+This project tracking card was created using the [BSSw PSIP Project Tracking Card Catalog](https://bssw-psip.github.io/ptc-catalog/), part of the Exascale Computing Project (ECP).

--- a/catalog/EpicsForTracking.md
+++ b/catalog/EpicsForTracking.md
@@ -27,4 +27,4 @@ As a project manager I want all staff to write Jira Epics representing LOE so th
 
 ### Acknowledgement
 
-This project tracking card was created using the [BSSw PSIP Project Tracking Card Catalog](https://bssw-psip.github.io/ptc-catalog/), part of the Exascale Computing Project (ECP).
+This Project Tracking Card originated from the [PSIP PTC Catalog](https://bssw-psip.github.io/ptc-catalog/). The development of the PSIP PTC Catalog was supported by the Exascale Computing Project (17-SC-20-SC), a collaborative effort of the U.S. Department of Energy Office of Science and the National Nuclear Security Administration.

--- a/catalog/EpicsForTracking.md
+++ b/catalog/EpicsForTracking.md
@@ -1,4 +1,4 @@
-[metadata:tags]:- "ecp-psip-ptc"
+[metadata:tags]:- "bssw-psip-ptc"
 # Using Epics in Jira for Tracking and Collaboration
 
 ## Target

--- a/catalog/EvaluateAndUseAnIssueTracker.md
+++ b/catalog/EvaluateAndUseAnIssueTracker.md
@@ -1,4 +1,4 @@
-[metadata:tags]:- "ecp-psip-ptc"
+[metadata:tags]:- "bssw-psip-ptc"
 # Evaluate and Use an Issue Tracker
 
 ## Target

--- a/catalog/EvaluateAndUseAnIssueTracker.md
+++ b/catalog/EvaluateAndUseAnIssueTracker.md
@@ -1,3 +1,4 @@
+[_metadata_:tags]:- "psip-ptc"
 # Evaluate and Use an Issue Tracker
 
 ## Target

--- a/catalog/EvaluateAndUseAnIssueTracker.md
+++ b/catalog/EvaluateAndUseAnIssueTracker.md
@@ -1,4 +1,4 @@
-[_metadata_:tags]:- "psip-ptc"
+[_metadata_:tags]:- "ecp-psip-ptc"
 # Evaluate and Use an Issue Tracker
 
 ## Target

--- a/catalog/EvaluateAndUseAnIssueTracker.md
+++ b/catalog/EvaluateAndUseAnIssueTracker.md
@@ -1,4 +1,4 @@
-[_metadata_:tags]:- "ecp-psip-ptc"
+[metadata:tags]:- "ecp-psip-ptc"
 # Evaluate and Use an Issue Tracker
 
 ## Target
@@ -35,3 +35,8 @@ As a software developer, I want to keep track of bugs and user feature requests 
 ----
 
 Thanks @prwolfe @jeanshuler for the help!
+
+
+### Acknowledgement
+
+This project tracking card was created using the [BSSw PSIP Project Tracking Card Catalog](https://bssw-psip.github.io/ptc-catalog/), part of the Exascale Computing Project (ECP).

--- a/catalog/EvaluateAndUseAnIssueTracker.md
+++ b/catalog/EvaluateAndUseAnIssueTracker.md
@@ -39,4 +39,4 @@ Thanks @prwolfe @jeanshuler for the help!
 
 ### Acknowledgement
 
-This project tracking card was created using the [BSSw PSIP Project Tracking Card Catalog](https://bssw-psip.github.io/ptc-catalog/), part of the Exascale Computing Project (ECP).
+This Project Tracking Card originated from the [PSIP PTC Catalog](https://bssw-psip.github.io/ptc-catalog/). The development of the PSIP PTC Catalog was supported by the Exascale Computing Project (17-SC-20-SC), a collaborative effort of the U.S. Department of Energy Office of Science and the National Nuclear Security Administration.

--- a/catalog/GitWorkflow.md
+++ b/catalog/GitWorkflow.md
@@ -1,4 +1,4 @@
-[_metadata_:tags]:- "ecp-psip-ptc"
+[metadata:tags]:- "ecp-psip-ptc"
 # Adopt A Git Workflow that Supports Testing and Peer-review
 
 ## Target
@@ -26,3 +26,8 @@ so that all code changes are peer-reviewed and tested.
 - Automated testing is testing branches within Github/Gitlab in isolation
 - The term "merge request" can be used interchangeably with "pull request"
 - Steps 4 & 5 can be done in either order
+
+
+### Acknowledgement
+
+This project tracking card was created using the [BSSw PSIP Project Tracking Card Catalog](https://bssw-psip.github.io/ptc-catalog/), part of the Exascale Computing Project (ECP).

--- a/catalog/GitWorkflow.md
+++ b/catalog/GitWorkflow.md
@@ -30,4 +30,4 @@ so that all code changes are peer-reviewed and tested.
 
 ### Acknowledgement
 
-This project tracking card was created using the [BSSw PSIP Project Tracking Card Catalog](https://bssw-psip.github.io/ptc-catalog/), part of the Exascale Computing Project (ECP).
+This Project Tracking Card originated from the [PSIP PTC Catalog](https://bssw-psip.github.io/ptc-catalog/). The development of the PSIP PTC Catalog was supported by the Exascale Computing Project (17-SC-20-SC), a collaborative effort of the U.S. Department of Energy Office of Science and the National Nuclear Security Administration.

--- a/catalog/GitWorkflow.md
+++ b/catalog/GitWorkflow.md
@@ -1,4 +1,4 @@
-[_metadata_:tags]:- "psip-ptc"
+[_metadata_:tags]:- "ecp-psip-ptc"
 # Adopt A Git Workflow that Supports Testing and Peer-review
 
 ## Target

--- a/catalog/GitWorkflow.md
+++ b/catalog/GitWorkflow.md
@@ -1,4 +1,4 @@
-[metadata:tags]:- "ecp-psip-ptc"
+[metadata:tags]:- "bssw-psip-ptc"
 # Adopt A Git Workflow that Supports Testing and Peer-review
 
 ## Target

--- a/catalog/GitWorkflow.md
+++ b/catalog/GitWorkflow.md
@@ -1,3 +1,4 @@
+[_metadata_:tags]:- "psip-ptc"
 # Adopt A Git Workflow that Supports Testing and Peer-review
 
 ## Target

--- a/catalog/ImprovingProjectVisibility.md
+++ b/catalog/ImprovingProjectVisibility.md
@@ -1,4 +1,4 @@
-[metadata:tags]:- "ecp-psip-ptc"
+[metadata:tags]:- "bssw-psip-ptc"
 # Improving Project Visibility: Using a Communication Plan
 
 ## Target

--- a/catalog/ImprovingProjectVisibility.md
+++ b/catalog/ImprovingProjectVisibility.md
@@ -33,4 +33,4 @@ within a specified time frame.
 
 ### Acknowledgement
 
-This project tracking card was created using the [BSSw PSIP Project Tracking Card Catalog](https://bssw-psip.github.io/ptc-catalog/), part of the Exascale Computing Project (ECP).
+This Project Tracking Card originated from the [PSIP PTC Catalog](https://bssw-psip.github.io/ptc-catalog/). The development of the PSIP PTC Catalog was supported by the Exascale Computing Project (17-SC-20-SC), a collaborative effort of the U.S. Department of Energy Office of Science and the National Nuclear Security Administration.

--- a/catalog/ImprovingProjectVisibility.md
+++ b/catalog/ImprovingProjectVisibility.md
@@ -1,4 +1,4 @@
-[_metadata_:tags]:- "ecp-psip-ptc"
+[metadata:tags]:- "ecp-psip-ptc"
 # Improving Project Visibility: Using a Communication Plan
 
 ## Target
@@ -29,3 +29,8 @@ within a specified time frame.
 3. Develop and implement an actionable plan to publicize the project to the community (e.g. for a research community, through posters and research publications) within a specified time frame. The plan should be achievable by team.
 4. The team has defined how "active" a social media presence will be required (e.g. 1 tweet per day, 1 blog post per week, etc.)
 5. The communication plan may be revised as the requirements for "ideal" visibility shift.
+
+
+### Acknowledgement
+
+This project tracking card was created using the [BSSw PSIP Project Tracking Card Catalog](https://bssw-psip.github.io/ptc-catalog/), part of the Exascale Computing Project (ECP).

--- a/catalog/ImprovingProjectVisibility.md
+++ b/catalog/ImprovingProjectVisibility.md
@@ -1,3 +1,4 @@
+[_metadata_:tags]:- "psip-ptc"
 # Improving Project Visibility: Using a Communication Plan
 
 ## Target

--- a/catalog/ImprovingProjectVisibility.md
+++ b/catalog/ImprovingProjectVisibility.md
@@ -1,4 +1,4 @@
-[_metadata_:tags]:- "psip-ptc"
+[_metadata_:tags]:- "ecp-psip-ptc"
 # Improving Project Visibility: Using a Communication Plan
 
 ## Target

--- a/catalog/IntegratedSoftwareDocumentation.md
+++ b/catalog/IntegratedSoftwareDocumentation.md
@@ -1,4 +1,4 @@
-[_metadata_:tags]:- "psip-ptc"
+[_metadata_:tags]:- "ecp-psip-ptc"
 # Integrated Software Documentation
 
 ## Target

--- a/catalog/IntegratedSoftwareDocumentation.md
+++ b/catalog/IntegratedSoftwareDocumentation.md
@@ -1,3 +1,4 @@
+[_metadata_:tags]:- "psip-ptc"
 # Integrated Software Documentation
 
 ## Target

--- a/catalog/IntegratedSoftwareDocumentation.md
+++ b/catalog/IntegratedSoftwareDocumentation.md
@@ -1,4 +1,4 @@
-[metadata:tags]:- "ecp-psip-ptc"
+[metadata:tags]:- "bssw-psip-ptc"
 # Integrated Software Documentation
 
 ## Target

--- a/catalog/IntegratedSoftwareDocumentation.md
+++ b/catalog/IntegratedSoftwareDocumentation.md
@@ -1,4 +1,4 @@
-[_metadata_:tags]:- "ecp-psip-ptc"
+[metadata:tags]:- "ecp-psip-ptc"
 # Integrated Software Documentation
 
 ## Target
@@ -35,3 +35,8 @@ Some useful technologies to consider are
 * [Sphinx](http://www.sphinx-doc.org/en/master/)
 * [ReadTheDocs](https://readthedocs.org)
 * [Jekyll](https://jekyllrb.com) and Jekyll's [Documentation Theme](https://jekyllthemes.io/jekyll-documentation-themes)
+
+
+### Acknowledgement
+
+This project tracking card was created using the [BSSw PSIP Project Tracking Card Catalog](https://bssw-psip.github.io/ptc-catalog/), part of the Exascale Computing Project (ECP).

--- a/catalog/IntegratedSoftwareDocumentation.md
+++ b/catalog/IntegratedSoftwareDocumentation.md
@@ -39,4 +39,4 @@ Some useful technologies to consider are
 
 ### Acknowledgement
 
-This project tracking card was created using the [BSSw PSIP Project Tracking Card Catalog](https://bssw-psip.github.io/ptc-catalog/), part of the Exascale Computing Project (ECP).
+This Project Tracking Card originated from the [PSIP PTC Catalog](https://bssw-psip.github.io/ptc-catalog/). The development of the PSIP PTC Catalog was supported by the Exascale Computing Project (17-SC-20-SC), a collaborative effort of the U.S. Department of Energy Office of Science and the National Nuclear Security Administration.

--- a/catalog/IssuesForDesign.md
+++ b/catalog/IssuesForDesign.md
@@ -23,4 +23,4 @@ As a software engineer I want my small team to use issues for developing new mod
 
 ### Acknowledgement
 
-This project tracking card was created using the [BSSw PSIP Project Tracking Card Catalog](https://bssw-psip.github.io/ptc-catalog/), part of the Exascale Computing Project (ECP).
+This Project Tracking Card originated from the [PSIP PTC Catalog](https://bssw-psip.github.io/ptc-catalog/). The development of the PSIP PTC Catalog was supported by the Exascale Computing Project (17-SC-20-SC), a collaborative effort of the U.S. Department of Energy Office of Science and the National Nuclear Security Administration.

--- a/catalog/IssuesForDesign.md
+++ b/catalog/IssuesForDesign.md
@@ -1,4 +1,4 @@
-[_metadata_:tags]:- "ecp-psip-ptc"
+[metadata:tags]:- "ecp-psip-ptc"
 # Using Issues on GitHub/GitLab for Design and Development
 
 ## User Story
@@ -19,3 +19,8 @@ As a software engineer I want my small team to use issues for developing new mod
 ## Comments
 
 1. To learn more see [What is Issue Tracking?](https://bssw.io/items/what-is-issue-tracking)
+
+
+### Acknowledgement
+
+This project tracking card was created using the [BSSw PSIP Project Tracking Card Catalog](https://bssw-psip.github.io/ptc-catalog/), part of the Exascale Computing Project (ECP).

--- a/catalog/IssuesForDesign.md
+++ b/catalog/IssuesForDesign.md
@@ -1,4 +1,4 @@
-[metadata:tags]:- "ecp-psip-ptc"
+[metadata:tags]:- "bssw-psip-ptc"
 # Using Issues on GitHub/GitLab for Design and Development
 
 ## User Story

--- a/catalog/IssuesForDesign.md
+++ b/catalog/IssuesForDesign.md
@@ -1,3 +1,4 @@
+[_metadata_:tags]:- "psip-ptc"
 # Using Issues on GitHub/GitLab for Design and Development
 
 ## User Story

--- a/catalog/IssuesForDesign.md
+++ b/catalog/IssuesForDesign.md
@@ -1,4 +1,4 @@
-[_metadata_:tags]:- "psip-ptc"
+[_metadata_:tags]:- "ecp-psip-ptc"
 # Using Issues on GitHub/GitLab for Design and Development
 
 ## User Story

--- a/catalog/MultiSystemPerformanceTesting.md
+++ b/catalog/MultiSystemPerformanceTesting.md
@@ -1,4 +1,4 @@
-[_metadata_:tags]:- "psip-ptc"
+[_metadata_:tags]:- "ecp-psip-ptc"
 # Multi-System Performance Testing
 
 ## Target

--- a/catalog/MultiSystemPerformanceTesting.md
+++ b/catalog/MultiSystemPerformanceTesting.md
@@ -1,3 +1,4 @@
+[_metadata_:tags]:- "psip-ptc"
 # Multi-System Performance Testing
 
 ## Target

--- a/catalog/MultiSystemPerformanceTesting.md
+++ b/catalog/MultiSystemPerformanceTesting.md
@@ -1,4 +1,4 @@
-[_metadata_:tags]:- "ecp-psip-ptc"
+[metadata:tags]:- "ecp-psip-ptc"
 # Multi-System Performance Testing
 
 ## Target
@@ -25,3 +25,8 @@ As a software engineer I want to incorporate regular performance testing into my
 - The [Performance Regression Testing Card](PerformanceRegressionTesting.md) has details on developing a performance regression tests itself.
 
 **This card originally proposed by [Boyana Norris](https://github.com/brnorris03)**
+
+
+### Acknowledgement
+
+This project tracking card was created using the [BSSw PSIP Project Tracking Card Catalog](https://bssw-psip.github.io/ptc-catalog/), part of the Exascale Computing Project (ECP).

--- a/catalog/MultiSystemPerformanceTesting.md
+++ b/catalog/MultiSystemPerformanceTesting.md
@@ -29,4 +29,4 @@ As a software engineer I want to incorporate regular performance testing into my
 
 ### Acknowledgement
 
-This project tracking card was created using the [BSSw PSIP Project Tracking Card Catalog](https://bssw-psip.github.io/ptc-catalog/), part of the Exascale Computing Project (ECP).
+This Project Tracking Card originated from the [PSIP PTC Catalog](https://bssw-psip.github.io/ptc-catalog/). The development of the PSIP PTC Catalog was supported by the Exascale Computing Project (17-SC-20-SC), a collaborative effort of the U.S. Department of Energy Office of Science and the National Nuclear Security Administration.

--- a/catalog/MultiSystemPerformanceTesting.md
+++ b/catalog/MultiSystemPerformanceTesting.md
@@ -1,4 +1,4 @@
-[metadata:tags]:- "ecp-psip-ptc"
+[metadata:tags]:- "bssw-psip-ptc"
 # Multi-System Performance Testing
 
 ## Target

--- a/catalog/OnboardingANewTeamMember.md
+++ b/catalog/OnboardingANewTeamMember.md
@@ -1,3 +1,4 @@
+[_metadata_:tags]:- "psip-ptc"
 # Onboarding A New Team Member
 
 ## Target

--- a/catalog/OnboardingANewTeamMember.md
+++ b/catalog/OnboardingANewTeamMember.md
@@ -23,4 +23,4 @@ become contributors to our project using our policies for software development.
 
 ### Acknowledgement
 
-This project tracking card was created using the [BSSw PSIP Project Tracking Card Catalog](https://bssw-psip.github.io/ptc-catalog/), part of the Exascale Computing Project (ECP).
+This Project Tracking Card originated from the [PSIP PTC Catalog](https://bssw-psip.github.io/ptc-catalog/). The development of the PSIP PTC Catalog was supported by the Exascale Computing Project (17-SC-20-SC), a collaborative effort of the U.S. Department of Energy Office of Science and the National Nuclear Security Administration.

--- a/catalog/OnboardingANewTeamMember.md
+++ b/catalog/OnboardingANewTeamMember.md
@@ -1,4 +1,4 @@
-[_metadata_:tags]:- "psip-ptc"
+[_metadata_:tags]:- "ecp-psip-ptc"
 # Onboarding A New Team Member
 
 ## Target

--- a/catalog/OnboardingANewTeamMember.md
+++ b/catalog/OnboardingANewTeamMember.md
@@ -1,4 +1,4 @@
-[_metadata_:tags]:- "ecp-psip-ptc"
+[metadata:tags]:- "ecp-psip-ptc"
 # Onboarding A New Team Member
 
 ## Target
@@ -19,3 +19,8 @@ become contributors to our project using our policies for software development.
 | 2 | The team onboarding process is used by supervisors for new hires.|
 | 3 | The team onboarding process is approved by HR. Regular reviews of the process are undertaken.|
 | 4 | All team members are familiar with, and actively participate in, the onboarding process.|
+
+
+### Acknowledgement
+
+This project tracking card was created using the [BSSw PSIP Project Tracking Card Catalog](https://bssw-psip.github.io/ptc-catalog/), part of the Exascale Computing Project (ECP).

--- a/catalog/OnboardingANewTeamMember.md
+++ b/catalog/OnboardingANewTeamMember.md
@@ -1,4 +1,4 @@
-[metadata:tags]:- "ecp-psip-ptc"
+[metadata:tags]:- "bssw-psip-ptc"
 # Onboarding A New Team Member
 
 ## Target

--- a/catalog/OpenSource.md
+++ b/catalog/OpenSource.md
@@ -1,4 +1,4 @@
-[_metadata_:tags]:- "ecp-psip-ptc"
+[metadata:tags]:- "ecp-psip-ptc"
 # Open Source
 
 ## Target
@@ -20,3 +20,8 @@ As a software developer I want to make my project open source so that I can enga
 | 4 | The backlog of bugs/issues is moved to an established, third-party hosting platform |
 
 ## Comments
+
+
+### Acknowledgement
+
+This project tracking card was created using the [BSSw PSIP Project Tracking Card Catalog](https://bssw-psip.github.io/ptc-catalog/), part of the Exascale Computing Project (ECP).

--- a/catalog/OpenSource.md
+++ b/catalog/OpenSource.md
@@ -1,4 +1,4 @@
-[metadata:tags]:- "ecp-psip-ptc"
+[metadata:tags]:- "bssw-psip-ptc"
 # Open Source
 
 ## Target

--- a/catalog/OpenSource.md
+++ b/catalog/OpenSource.md
@@ -24,4 +24,4 @@ As a software developer I want to make my project open source so that I can enga
 
 ### Acknowledgement
 
-This project tracking card was created using the [BSSw PSIP Project Tracking Card Catalog](https://bssw-psip.github.io/ptc-catalog/), part of the Exascale Computing Project (ECP).
+This Project Tracking Card originated from the [PSIP PTC Catalog](https://bssw-psip.github.io/ptc-catalog/). The development of the PSIP PTC Catalog was supported by the Exascale Computing Project (17-SC-20-SC), a collaborative effort of the U.S. Department of Energy Office of Science and the National Nuclear Security Administration.

--- a/catalog/OpenSource.md
+++ b/catalog/OpenSource.md
@@ -1,4 +1,4 @@
-[_metadata_:tags]:- "psip-ptc"
+[_metadata_:tags]:- "ecp-psip-ptc"
 # Open Source
 
 ## Target

--- a/catalog/OpenSource.md
+++ b/catalog/OpenSource.md
@@ -1,3 +1,4 @@
+[_metadata_:tags]:- "psip-ptc"
 # Open Source
 
 ## Target

--- a/catalog/PeerProgress.md
+++ b/catalog/PeerProgress.md
@@ -34,4 +34,4 @@ datastructures and API-s can be made inter-operable early on.
 
 ### Acknowledgement
 
-This project tracking card was created using the [BSSw PSIP Project Tracking Card Catalog](https://bssw-psip.github.io/ptc-catalog/), part of the Exascale Computing Project (ECP).
+This Project Tracking Card originated from the [PSIP PTC Catalog](https://bssw-psip.github.io/ptc-catalog/). The development of the PSIP PTC Catalog was supported by the Exascale Computing Project (17-SC-20-SC), a collaborative effort of the U.S. Department of Energy Office of Science and the National Nuclear Security Administration.

--- a/catalog/PeerProgress.md
+++ b/catalog/PeerProgress.md
@@ -1,3 +1,4 @@
+[_metadata_:tags]:- "psip-ptc"
 # Tracking and Adjusting to Progress in Peer Projects
 
 ## Target

--- a/catalog/PeerProgress.md
+++ b/catalog/PeerProgress.md
@@ -1,4 +1,4 @@
-[_metadata_:tags]:- "ecp-psip-ptc"
+[metadata:tags]:- "ecp-psip-ptc"
 # Tracking and Adjusting to Progress in Peer Projects
 
 ## Target
@@ -30,3 +30,8 @@ can also be a source of new collaborators and increased productivity.
 - Tracking peer progress looks different in different disciplines, but is especially
 important where software development is involved because of the potential win if
 datastructures and API-s can be made inter-operable early on.
+
+
+### Acknowledgement
+
+This project tracking card was created using the [BSSw PSIP Project Tracking Card Catalog](https://bssw-psip.github.io/ptc-catalog/), part of the Exascale Computing Project (ECP).

--- a/catalog/PeerProgress.md
+++ b/catalog/PeerProgress.md
@@ -1,4 +1,4 @@
-[metadata:tags]:- "ecp-psip-ptc"
+[metadata:tags]:- "bssw-psip-ptc"
 # Tracking and Adjusting to Progress in Peer Projects
 
 ## Target

--- a/catalog/PeerProgress.md
+++ b/catalog/PeerProgress.md
@@ -1,4 +1,4 @@
-[_metadata_:tags]:- "psip-ptc"
+[_metadata_:tags]:- "ecp-psip-ptc"
 # Tracking and Adjusting to Progress in Peer Projects
 
 ## Target

--- a/catalog/PerformanceRegressionTesting.md
+++ b/catalog/PerformanceRegressionTesting.md
@@ -1,4 +1,4 @@
-[metadata:tags]:- "ecp-psip-ptc"
+[metadata:tags]:- "bssw-psip-ptc"
 # Performance Regression Testing
 
 ## Target

--- a/catalog/PerformanceRegressionTesting.md
+++ b/catalog/PerformanceRegressionTesting.md
@@ -1,4 +1,4 @@
-[_metadata_:tags]:- "psip-ptc"
+[_metadata_:tags]:- "ecp-psip-ptc"
 # Performance Regression Testing
 
 ## Target

--- a/catalog/PerformanceRegressionTesting.md
+++ b/catalog/PerformanceRegressionTesting.md
@@ -1,4 +1,4 @@
-[_metadata_:tags]:- "ecp-psip-ptc"
+[metadata:tags]:- "ecp-psip-ptc"
 # Performance Regression Testing
 
 ## Target
@@ -30,3 +30,8 @@ and others. The choice of measurements will inform the test(s) that need to be w
 - A performance test should be able to be checked relatively easily yet it is one that also exercises the code adequately.
 - Additional steps in this PTC might include repeating these steps to support another use case, set of measurements, 
 and/or more tests.
+
+
+### Acknowledgement
+
+This project tracking card was created using the [BSSw PSIP Project Tracking Card Catalog](https://bssw-psip.github.io/ptc-catalog/), part of the Exascale Computing Project (ECP).

--- a/catalog/PerformanceRegressionTesting.md
+++ b/catalog/PerformanceRegressionTesting.md
@@ -34,4 +34,4 @@ and/or more tests.
 
 ### Acknowledgement
 
-This project tracking card was created using the [BSSw PSIP Project Tracking Card Catalog](https://bssw-psip.github.io/ptc-catalog/), part of the Exascale Computing Project (ECP).
+This Project Tracking Card originated from the [PSIP PTC Catalog](https://bssw-psip.github.io/ptc-catalog/). The development of the PSIP PTC Catalog was supported by the Exascale Computing Project (17-SC-20-SC), a collaborative effort of the U.S. Department of Energy Office of Science and the National Nuclear Security Administration.

--- a/catalog/PerformanceRegressionTesting.md
+++ b/catalog/PerformanceRegressionTesting.md
@@ -1,3 +1,4 @@
+[_metadata_:tags]:- "psip-ptc"
 # Performance Regression Testing
 
 ## Target

--- a/catalog/README.md
+++ b/catalog/README.md
@@ -1,4 +1,4 @@
-[_metadata_:tags]:- "ecp-psip-ptc"
+[metadata:tags]:- "ecp-psip-ptc"
 # PTC Catalog Table of Contents
 
  The table below lists the currently available Progress Tracking Cards (PTCs) with a brief description of their goals.
@@ -43,3 +43,8 @@
 | [Transmedia Learning Framework for Python](TransmediaLearningForPython.md) | Learn Python enough to more efficiently recall functionality on demand. | 
 | [Promote User Confidence in Software Updates ](UserConfidenceSoftwareUpdates.md) | Ensure users are confident of application performance and behavior changes made by an update/new release. | 
 | [End-user Documentation](UserDocumentation.md) | Create end-user documentation for a software project | 
+
+
+### Acknowledgement
+
+This project tracking card was created using the [BSSw PSIP Project Tracking Card Catalog](https://bssw-psip.github.io/ptc-catalog/), part of the Exascale Computing Project (ECP).

--- a/catalog/README.md
+++ b/catalog/README.md
@@ -1,4 +1,4 @@
-[_metadata_:tags]:- "psip-ptc"
+[_metadata_:tags]:- "ecp-psip-ptc"
 # PTC Catalog Table of Contents
 
  The table below lists the currently available Progress Tracking Cards (PTCs) with a brief description of their goals.

--- a/catalog/README.md
+++ b/catalog/README.md
@@ -1,3 +1,4 @@
+[_metadata_:tags]:- "psip-ptc"
 # PTC Catalog Table of Contents
 
  The table below lists the currently available Progress Tracking Cards (PTCs) with a brief description of their goals.

--- a/catalog/README.md
+++ b/catalog/README.md
@@ -1,4 +1,4 @@
-[metadata:tags]:- "ecp-psip-ptc"
+[metadata:tags]:- "bssw-psip-ptc"
 # PTC Catalog Table of Contents
 
  The table below lists the currently available Progress Tracking Cards (PTCs) with a brief description of their goals.

--- a/catalog/README.md
+++ b/catalog/README.md
@@ -47,4 +47,4 @@
 
 ### Acknowledgement
 
-This project tracking card was created using the [BSSw PSIP Project Tracking Card Catalog](https://bssw-psip.github.io/ptc-catalog/), part of the Exascale Computing Project (ECP).
+This Project Tracking Card originated from the [PSIP PTC Catalog](https://bssw-psip.github.io/ptc-catalog/). The development of the PSIP PTC Catalog was supported by the Exascale Computing Project (17-SC-20-SC), a collaborative effort of the U.S. Department of Energy Office of Science and the National Nuclear Security Administration.

--- a/catalog/RequirementsEngineering.md
+++ b/catalog/RequirementsEngineering.md
@@ -37,4 +37,4 @@ Created at the SEA ISC'22 PSIP tutorial by Erik Kluzek, Christina Holt, Edward H
 
 ### Acknowledgement
 
-This project tracking card was created using the [BSSw PSIP Project Tracking Card Catalog](https://bssw-psip.github.io/ptc-catalog/), part of the Exascale Computing Project (ECP).
+This Project Tracking Card originated from the [PSIP PTC Catalog](https://bssw-psip.github.io/ptc-catalog/). The development of the PSIP PTC Catalog was supported by the Exascale Computing Project (17-SC-20-SC), a collaborative effort of the U.S. Department of Energy Office of Science and the National Nuclear Security Administration.

--- a/catalog/RequirementsEngineering.md
+++ b/catalog/RequirementsEngineering.md
@@ -1,4 +1,4 @@
-[_metadata_:tags]:- "ecp-psip-ptc"
+[metadata:tags]:- "ecp-psip-ptc"
 # Requirements Engineering
 ## Target
 
@@ -33,3 +33,8 @@ Created at the SEA ISC'22 PSIP tutorial by Erik Kluzek, Christina Holt, Edward H
 [What Are CSE Software Requirements?](https://bssw.io/items/what-are-cse-software-requirements)
 
 [An Introduction to User Stories and How to Write Them](https://bssw.io/items/an-introduction-to-user-stories-and-how-to-write-them)
+
+
+### Acknowledgement
+
+This project tracking card was created using the [BSSw PSIP Project Tracking Card Catalog](https://bssw-psip.github.io/ptc-catalog/), part of the Exascale Computing Project (ECP).

--- a/catalog/RequirementsEngineering.md
+++ b/catalog/RequirementsEngineering.md
@@ -1,3 +1,4 @@
+[_metadata_:tags]:- "psip-ptc"
 # Requirements Engineering
 ## Target
 

--- a/catalog/RequirementsEngineering.md
+++ b/catalog/RequirementsEngineering.md
@@ -1,4 +1,4 @@
-[_metadata_:tags]:- "psip-ptc"
+[_metadata_:tags]:- "ecp-psip-ptc"
 # Requirements Engineering
 ## Target
 

--- a/catalog/RequirementsEngineering.md
+++ b/catalog/RequirementsEngineering.md
@@ -1,4 +1,4 @@
-[metadata:tags]:- "ecp-psip-ptc"
+[metadata:tags]:- "bssw-psip-ptc"
 # Requirements Engineering
 ## Target
 

--- a/catalog/SoftwareLicensing.md
+++ b/catalog/SoftwareLicensing.md
@@ -32,4 +32,4 @@ As a contributor to a software package, I want to ensure that our work has an ap
 
 ### Acknowledgement
 
-This project tracking card was created using the [BSSw PSIP Project Tracking Card Catalog](https://bssw-psip.github.io/ptc-catalog/), part of the Exascale Computing Project (ECP).
+This Project Tracking Card originated from the [PSIP PTC Catalog](https://bssw-psip.github.io/ptc-catalog/). The development of the PSIP PTC Catalog was supported by the Exascale Computing Project (17-SC-20-SC), a collaborative effort of the U.S. Department of Energy Office of Science and the National Nuclear Security Administration.

--- a/catalog/SoftwareLicensing.md
+++ b/catalog/SoftwareLicensing.md
@@ -1,3 +1,4 @@
+[_metadata_:tags]:- "psip-ptc"
 # Licensing Your Software
 
 ## Target

--- a/catalog/SoftwareLicensing.md
+++ b/catalog/SoftwareLicensing.md
@@ -1,4 +1,4 @@
-[metadata:tags]:- "ecp-psip-ptc"
+[metadata:tags]:- "bssw-psip-ptc"
 # Licensing Your Software
 
 ## Target

--- a/catalog/SoftwareLicensing.md
+++ b/catalog/SoftwareLicensing.md
@@ -1,4 +1,4 @@
-[_metadata_:tags]:- "ecp-psip-ptc"
+[metadata:tags]:- "ecp-psip-ptc"
 # Licensing Your Software
 
 ## Target
@@ -28,3 +28,8 @@ As a contributor to a software package, I want to ensure that our work has an ap
 
 [1]: http://softwarefreedom.org/resources/2012/ManagingCopyrightInformation.html
 
+
+
+### Acknowledgement
+
+This project tracking card was created using the [BSSw PSIP Project Tracking Card Catalog](https://bssw-psip.github.io/ptc-catalog/), part of the Exascale Computing Project (ECP).

--- a/catalog/SoftwareLicensing.md
+++ b/catalog/SoftwareLicensing.md
@@ -1,4 +1,4 @@
-[_metadata_:tags]:- "psip-ptc"
+[_metadata_:tags]:- "ecp-psip-ptc"
 # Licensing Your Software
 
 ## Target

--- a/catalog/SourceManagement.md
+++ b/catalog/SourceManagement.md
@@ -1,4 +1,4 @@
-[_metadata_:tags]:- "psip-ptc"
+[_metadata_:tags]:- "ecp-psip-ptc"
 # Source Management
 
 ## Target

--- a/catalog/SourceManagement.md
+++ b/catalog/SourceManagement.md
@@ -1,3 +1,4 @@
+[_metadata_:tags]:- "psip-ptc"
 # Source Management
 
 ## Target

--- a/catalog/SourceManagement.md
+++ b/catalog/SourceManagement.md
@@ -1,4 +1,4 @@
-[_metadata_:tags]:- "ecp-psip-ptc"
+[metadata:tags]:- "ecp-psip-ptc"
 # Source Management
 
 ## Target
@@ -18,3 +18,8 @@ Use Source Management System (SMS).
 
 
 ## Comments
+
+
+### Acknowledgement
+
+This project tracking card was created using the [BSSw PSIP Project Tracking Card Catalog](https://bssw-psip.github.io/ptc-catalog/), part of the Exascale Computing Project (ECP).

--- a/catalog/SourceManagement.md
+++ b/catalog/SourceManagement.md
@@ -1,4 +1,4 @@
-[metadata:tags]:- "ecp-psip-ptc"
+[metadata:tags]:- "bssw-psip-ptc"
 # Source Management
 
 ## Target

--- a/catalog/SourceManagement.md
+++ b/catalog/SourceManagement.md
@@ -22,4 +22,4 @@ Use Source Management System (SMS).
 
 ### Acknowledgement
 
-This project tracking card was created using the [BSSw PSIP Project Tracking Card Catalog](https://bssw-psip.github.io/ptc-catalog/), part of the Exascale Computing Project (ECP).
+This Project Tracking Card originated from the [PSIP PTC Catalog](https://bssw-psip.github.io/ptc-catalog/). The development of the PSIP PTC Catalog was supported by the Exascale Computing Project (17-SC-20-SC), a collaborative effort of the U.S. Department of Energy Office of Science and the National Nuclear Security Administration.

--- a/catalog/THGCodingStandards.md
+++ b/catalog/THGCodingStandards.md
@@ -1,4 +1,4 @@
-[_metadata_:tags]:- "ecp-psip-ptc"
+[metadata:tags]:- "ecp-psip-ptc"
 # THG Coding Standards
 
 ## Target
@@ -44,3 +44,8 @@ As an HDF5 library developer or community contributor, I want support so that I 
 ## Other Remarks
 
 This card was created by the [THG PSIP Pilot project](https://www.osti.gov/biblio/1698291-psip-hdf5pilot-project-final-report).
+
+
+### Acknowledgement
+
+This project tracking card was created using the [BSSw PSIP Project Tracking Card Catalog](https://bssw-psip.github.io/ptc-catalog/), part of the Exascale Computing Project (ECP).

--- a/catalog/THGCodingStandards.md
+++ b/catalog/THGCodingStandards.md
@@ -1,3 +1,4 @@
+[_metadata_:tags]:- "psip-ptc"
 # THG Coding Standards
 
 ## Target

--- a/catalog/THGCodingStandards.md
+++ b/catalog/THGCodingStandards.md
@@ -48,4 +48,4 @@ This card was created by the [THG PSIP Pilot project](https://www.osti.gov/bibli
 
 ### Acknowledgement
 
-This project tracking card was created using the [BSSw PSIP Project Tracking Card Catalog](https://bssw-psip.github.io/ptc-catalog/), part of the Exascale Computing Project (ECP).
+This Project Tracking Card originated from the [PSIP PTC Catalog](https://bssw-psip.github.io/ptc-catalog/). The development of the PSIP PTC Catalog was supported by the Exascale Computing Project (17-SC-20-SC), a collaborative effort of the U.S. Department of Energy Office of Science and the National Nuclear Security Administration.

--- a/catalog/THGCodingStandards.md
+++ b/catalog/THGCodingStandards.md
@@ -1,4 +1,4 @@
-[_metadata_:tags]:- "psip-ptc"
+[_metadata_:tags]:- "ecp-psip-ptc"
 # THG Coding Standards
 
 ## Target

--- a/catalog/THGCodingStandards.md
+++ b/catalog/THGCodingStandards.md
@@ -1,4 +1,4 @@
-[metadata:tags]:- "ecp-psip-ptc"
+[metadata:tags]:- "bssw-psip-ptc"
 # THG Coding Standards
 
 ## Target

--- a/catalog/THGGitHubMigration.md
+++ b/catalog/THGGitHubMigration.md
@@ -1,4 +1,4 @@
-[_metadata_:tags]:- "ecp-psip-ptc"
+[metadata:tags]:- "ecp-psip-ptc"
 # THG GitHub Migration
 
 ## Target
@@ -33,3 +33,8 @@ As a community contributor, I want my contributions to be held to the same stand
 ## Other Remarks
 
 This card was created by the [THG PSIP Pilot project](https://www.osti.gov/biblio/1698291-psip-hdf5pilot-project-final-report).
+
+
+### Acknowledgement
+
+This project tracking card was created using the [BSSw PSIP Project Tracking Card Catalog](https://bssw-psip.github.io/ptc-catalog/), part of the Exascale Computing Project (ECP).

--- a/catalog/THGGitHubMigration.md
+++ b/catalog/THGGitHubMigration.md
@@ -1,4 +1,4 @@
-[metadata:tags]:- "ecp-psip-ptc"
+[metadata:tags]:- "bssw-psip-ptc"
 # THG GitHub Migration
 
 ## Target

--- a/catalog/THGGitHubMigration.md
+++ b/catalog/THGGitHubMigration.md
@@ -1,3 +1,4 @@
+[_metadata_:tags]:- "psip-ptc"
 # THG GitHub Migration
 
 ## Target

--- a/catalog/THGGitHubMigration.md
+++ b/catalog/THGGitHubMigration.md
@@ -37,4 +37,4 @@ This card was created by the [THG PSIP Pilot project](https://www.osti.gov/bibli
 
 ### Acknowledgement
 
-This project tracking card was created using the [BSSw PSIP Project Tracking Card Catalog](https://bssw-psip.github.io/ptc-catalog/), part of the Exascale Computing Project (ECP).
+This Project Tracking Card originated from the [PSIP PTC Catalog](https://bssw-psip.github.io/ptc-catalog/). The development of the PSIP PTC Catalog was supported by the Exascale Computing Project (17-SC-20-SC), a collaborative effort of the U.S. Department of Energy Office of Science and the National Nuclear Security Administration.

--- a/catalog/THGGitHubMigration.md
+++ b/catalog/THGGitHubMigration.md
@@ -1,4 +1,4 @@
-[_metadata_:tags]:- "psip-ptc"
+[_metadata_:tags]:- "ecp-psip-ptc"
 # THG GitHub Migration
 
 ## Target

--- a/catalog/THGReferenceManual.md
+++ b/catalog/THGReferenceManual.md
@@ -38,4 +38,4 @@ This card was created by the [THG PSIP Pilot project](https://www.osti.gov/bibli
 
 ### Acknowledgement
 
-This project tracking card was created using the [BSSw PSIP Project Tracking Card Catalog](https://bssw-psip.github.io/ptc-catalog/), part of the Exascale Computing Project (ECP).
+This Project Tracking Card originated from the [PSIP PTC Catalog](https://bssw-psip.github.io/ptc-catalog/). The development of the PSIP PTC Catalog was supported by the Exascale Computing Project (17-SC-20-SC), a collaborative effort of the U.S. Department of Energy Office of Science and the National Nuclear Security Administration.

--- a/catalog/THGReferenceManual.md
+++ b/catalog/THGReferenceManual.md
@@ -1,3 +1,4 @@
+[_metadata_:tags]:- "psip-ptc"
 # THG Reference Manual
 
 ## Target

--- a/catalog/THGReferenceManual.md
+++ b/catalog/THGReferenceManual.md
@@ -1,4 +1,4 @@
-[_metadata_:tags]:- "psip-ptc"
+[_metadata_:tags]:- "ecp-psip-ptc"
 # THG Reference Manual
 
 ## Target

--- a/catalog/THGReferenceManual.md
+++ b/catalog/THGReferenceManual.md
@@ -1,4 +1,4 @@
-[metadata:tags]:- "ecp-psip-ptc"
+[metadata:tags]:- "bssw-psip-ptc"
 # THG Reference Manual
 
 ## Target

--- a/catalog/THGReferenceManual.md
+++ b/catalog/THGReferenceManual.md
@@ -1,4 +1,4 @@
-[_metadata_:tags]:- "ecp-psip-ptc"
+[metadata:tags]:- "ecp-psip-ptc"
 # THG Reference Manual
 
 ## Target
@@ -34,3 +34,8 @@ As an HDF5 stakeholder, I want an easy-to-use reference manual, so that I can ha
 ## Other Remarks
 
 This card was created by the [THG PSIP Pilot project](https://www.osti.gov/biblio/1698291-psip-hdf5pilot-project-final-report).
+
+
+### Acknowledgement
+
+This project tracking card was created using the [BSSw PSIP Project Tracking Card Catalog](https://bssw-psip.github.io/ptc-catalog/), part of the Exascale Computing Project (ECP).

--- a/catalog/TestCoverage.md
+++ b/catalog/TestCoverage.md
@@ -1,4 +1,4 @@
-[metadata:tags]:- "ecp-psip-ptc"
+[metadata:tags]:- "bssw-psip-ptc"
 # Test Coverage
 
 

--- a/catalog/TestCoverage.md
+++ b/catalog/TestCoverage.md
@@ -1,4 +1,4 @@
-[_metadata_:tags]:- "psip-ptc"
+[_metadata_:tags]:- "ecp-psip-ptc"
 # Test Coverage
 
 

--- a/catalog/TestCoverage.md
+++ b/catalog/TestCoverage.md
@@ -1,3 +1,4 @@
+[_metadata_:tags]:- "psip-ptc"
 # Test Coverage
 
 

--- a/catalog/TestCoverage.md
+++ b/catalog/TestCoverage.md
@@ -1,4 +1,4 @@
-[_metadata_:tags]:- "ecp-psip-ptc"
+[metadata:tags]:- "ecp-psip-ptc"
 # Test Coverage
 
 
@@ -18,3 +18,8 @@
 2. **Unit testing**: Isolated, independent testing of functions and methods.  Enable test-driven development, rapid test execution, fault isolation.  Insufficient to ensure functional correctness.
 3. **Comprehensive**: Does not mean 100% line coverage, but sufficient coverage to detect most errors.  Experts suggest various metrics such as 80% or more line coverage, or some similar high percentage of function point coverage.
 4. **Commitment**: Team is committed to writing comprehensive tests concurrent with functionality.
+
+
+### Acknowledgement
+
+This project tracking card was created using the [BSSw PSIP Project Tracking Card Catalog](https://bssw-psip.github.io/ptc-catalog/), part of the Exascale Computing Project (ECP).

--- a/catalog/TestCoverage.md
+++ b/catalog/TestCoverage.md
@@ -22,4 +22,4 @@
 
 ### Acknowledgement
 
-This project tracking card was created using the [BSSw PSIP Project Tracking Card Catalog](https://bssw-psip.github.io/ptc-catalog/), part of the Exascale Computing Project (ECP).
+This Project Tracking Card originated from the [PSIP PTC Catalog](https://bssw-psip.github.io/ptc-catalog/). The development of the PSIP PTC Catalog was supported by the Exascale Computing Project (17-SC-20-SC), a collaborative effort of the U.S. Department of Energy Office of Science and the National Nuclear Security Administration.

--- a/catalog/TestDrivenDevelopment.md
+++ b/catalog/TestDrivenDevelopment.md
@@ -1,3 +1,4 @@
+[_metadata_:tags]:- "psip-ptc"
 # Test Driven Development
 
 ## Target

--- a/catalog/TestDrivenDevelopment.md
+++ b/catalog/TestDrivenDevelopment.md
@@ -31,4 +31,4 @@ is assumed to be the topic of a separate PTC.
 
 ### Acknowledgement
 
-This project tracking card was created using the [BSSw PSIP Project Tracking Card Catalog](https://bssw-psip.github.io/ptc-catalog/), part of the Exascale Computing Project (ECP).
+This Project Tracking Card originated from the [PSIP PTC Catalog](https://bssw-psip.github.io/ptc-catalog/). The development of the PSIP PTC Catalog was supported by the Exascale Computing Project (17-SC-20-SC), a collaborative effort of the U.S. Department of Energy Office of Science and the National Nuclear Security Administration.

--- a/catalog/TestDrivenDevelopment.md
+++ b/catalog/TestDrivenDevelopment.md
@@ -1,4 +1,4 @@
-[metadata:tags]:- "ecp-psip-ptc"
+[metadata:tags]:- "bssw-psip-ptc"
 # Test Driven Development
 
 ## Target

--- a/catalog/TestDrivenDevelopment.md
+++ b/catalog/TestDrivenDevelopment.md
@@ -1,4 +1,4 @@
-[_metadata_:tags]:- "psip-ptc"
+[_metadata_:tags]:- "ecp-psip-ptc"
 # Test Driven Development
 
 ## Target

--- a/catalog/TestDrivenDevelopment.md
+++ b/catalog/TestDrivenDevelopment.md
@@ -1,4 +1,4 @@
-[_metadata_:tags]:- "ecp-psip-ptc"
+[metadata:tags]:- "ecp-psip-ptc"
 # Test Driven Development
 
 ## Target
@@ -27,3 +27,8 @@ will be improved.
 1. Although not stricly necessary, TDD is assisted by employing continuous integration (CI). Establishing CI for a project
 is assumed to be the topic of a separate PTC.
 2. No assumption is made about the state of tests currently provided by the project, or to increase the test coverage of legacy code.
+
+
+### Acknowledgement
+
+This project tracking card was created using the [BSSw PSIP Project Tracking Card Catalog](https://bssw-psip.github.io/ptc-catalog/), part of the Exascale Computing Project (ECP).

--- a/catalog/TransitionToGitRevisionControl.md
+++ b/catalog/TransitionToGitRevisionControl.md
@@ -27,4 +27,4 @@ As a software engineer I want to use Git revision control, so that the team is a
 
 ### Acknowledgement
 
-This project tracking card was created using the [BSSw PSIP Project Tracking Card Catalog](https://bssw-psip.github.io/ptc-catalog/), part of the Exascale Computing Project (ECP).
+This Project Tracking Card originated from the [PSIP PTC Catalog](https://bssw-psip.github.io/ptc-catalog/). The development of the PSIP PTC Catalog was supported by the Exascale Computing Project (17-SC-20-SC), a collaborative effort of the U.S. Department of Energy Office of Science and the National Nuclear Security Administration.

--- a/catalog/TransitionToGitRevisionControl.md
+++ b/catalog/TransitionToGitRevisionControl.md
@@ -1,4 +1,4 @@
-[_metadata_:tags]:- "psip-ptc"
+[_metadata_:tags]:- "ecp-psip-ptc"
 # Transitioning to Git Revision Control
 
 ## Target

--- a/catalog/TransitionToGitRevisionControl.md
+++ b/catalog/TransitionToGitRevisionControl.md
@@ -1,4 +1,4 @@
-[metadata:tags]:- "ecp-psip-ptc"
+[metadata:tags]:- "bssw-psip-ptc"
 # Transitioning to Git Revision Control
 
 ## Target

--- a/catalog/TransitionToGitRevisionControl.md
+++ b/catalog/TransitionToGitRevisionControl.md
@@ -1,4 +1,4 @@
-[_metadata_:tags]:- "ecp-psip-ptc"
+[metadata:tags]:- "ecp-psip-ptc"
 # Transitioning to Git Revision Control
 
 ## Target
@@ -23,3 +23,8 @@ As a software engineer I want to use Git revision control, so that the team is a
 
 ## Comments
 - During Step 3, the transition to Git is in progress; some development still relies on an old revision control system, with regular synchronization between repositories.
+
+
+### Acknowledgement
+
+This project tracking card was created using the [BSSw PSIP Project Tracking Card Catalog](https://bssw-psip.github.io/ptc-catalog/), part of the Exascale Computing Project (ECP).

--- a/catalog/TransitionToGitRevisionControl.md
+++ b/catalog/TransitionToGitRevisionControl.md
@@ -1,3 +1,4 @@
+[_metadata_:tags]:- "psip-ptc"
 # Transitioning to Git Revision Control
 
 ## Target

--- a/catalog/TransmediaLearningForGit.md
+++ b/catalog/TransmediaLearningForGit.md
@@ -1,4 +1,4 @@
-[_metadata_:tags]:- "psip-ptc"
+[_metadata_:tags]:- "ecp-psip-ptc"
 # Transmedia Learning Framework for Git
 
 ## Target

--- a/catalog/TransmediaLearningForGit.md
+++ b/catalog/TransmediaLearningForGit.md
@@ -1,4 +1,4 @@
-[_metadata_:tags]:- "ecp-psip-ptc"
+[metadata:tags]:- "ecp-psip-ptc"
 # Transmedia Learning Framework for Git
 
 ## Target
@@ -35,3 +35,8 @@ As a casual user of Git I want more Git tutorials and tips so that it becomes ea
 
 ## Comments
 1. See [On-demand Learning for Better Scientific Software: How to Use Resources & Technology to Optimize your Productivity](http://ideas-productivity.org/events/hpc-best-practices-webinars/#webinar018) for details on the framework used in these progress tracking cards.
+
+
+### Acknowledgement
+
+This project tracking card was created using the [BSSw PSIP Project Tracking Card Catalog](https://bssw-psip.github.io/ptc-catalog/), part of the Exascale Computing Project (ECP).

--- a/catalog/TransmediaLearningForGit.md
+++ b/catalog/TransmediaLearningForGit.md
@@ -1,4 +1,4 @@
-[metadata:tags]:- "ecp-psip-ptc"
+[metadata:tags]:- "bssw-psip-ptc"
 # Transmedia Learning Framework for Git
 
 ## Target

--- a/catalog/TransmediaLearningForGit.md
+++ b/catalog/TransmediaLearningForGit.md
@@ -39,4 +39,4 @@ As a casual user of Git I want more Git tutorials and tips so that it becomes ea
 
 ### Acknowledgement
 
-This project tracking card was created using the [BSSw PSIP Project Tracking Card Catalog](https://bssw-psip.github.io/ptc-catalog/), part of the Exascale Computing Project (ECP).
+This Project Tracking Card originated from the [PSIP PTC Catalog](https://bssw-psip.github.io/ptc-catalog/). The development of the PSIP PTC Catalog was supported by the Exascale Computing Project (17-SC-20-SC), a collaborative effort of the U.S. Department of Energy Office of Science and the National Nuclear Security Administration.

--- a/catalog/TransmediaLearningForGit.md
+++ b/catalog/TransmediaLearningForGit.md
@@ -1,3 +1,4 @@
+[_metadata_:tags]:- "psip-ptc"
 # Transmedia Learning Framework for Git
 
 ## Target

--- a/catalog/TransmediaLearningForPython.md
+++ b/catalog/TransmediaLearningForPython.md
@@ -39,4 +39,4 @@ As a casual user of Python I want more Python tutorials and tips so that it beco
 
 ### Acknowledgement
 
-This project tracking card was created using the [BSSw PSIP Project Tracking Card Catalog](https://bssw-psip.github.io/ptc-catalog/), part of the Exascale Computing Project (ECP).
+This Project Tracking Card originated from the [PSIP PTC Catalog](https://bssw-psip.github.io/ptc-catalog/). The development of the PSIP PTC Catalog was supported by the Exascale Computing Project (17-SC-20-SC), a collaborative effort of the U.S. Department of Energy Office of Science and the National Nuclear Security Administration.

--- a/catalog/TransmediaLearningForPython.md
+++ b/catalog/TransmediaLearningForPython.md
@@ -1,4 +1,4 @@
-[metadata:tags]:- "ecp-psip-ptc"
+[metadata:tags]:- "bssw-psip-ptc"
 # Transmedia Learning Framework for Python
 
 ## Target

--- a/catalog/TransmediaLearningForPython.md
+++ b/catalog/TransmediaLearningForPython.md
@@ -1,4 +1,4 @@
-[_metadata_:tags]:- "psip-ptc"
+[_metadata_:tags]:- "ecp-psip-ptc"
 # Transmedia Learning Framework for Python
 
 ## Target

--- a/catalog/TransmediaLearningForPython.md
+++ b/catalog/TransmediaLearningForPython.md
@@ -1,3 +1,4 @@
+[_metadata_:tags]:- "psip-ptc"
 # Transmedia Learning Framework for Python
 
 ## Target

--- a/catalog/TransmediaLearningForPython.md
+++ b/catalog/TransmediaLearningForPython.md
@@ -1,4 +1,4 @@
-[_metadata_:tags]:- "ecp-psip-ptc"
+[metadata:tags]:- "ecp-psip-ptc"
 # Transmedia Learning Framework for Python
 
 ## Target
@@ -35,3 +35,8 @@ As a casual user of Python I want more Python tutorials and tips so that it beco
 
 # Comments
 1. To complete the actions on this progress tracking card (PTC) and learn more about the TLF framework see  [On-demand Learning for Better Scientific Software: How to Use Resources & Technology to Optimize your Productivity](http://ideas-productivity.org/events/hpc-best-practices-webinars/#webinar018).
+
+
+### Acknowledgement
+
+This project tracking card was created using the [BSSw PSIP Project Tracking Card Catalog](https://bssw-psip.github.io/ptc-catalog/), part of the Exascale Computing Project (ECP).

--- a/catalog/UserConfidenceSoftwareUpdates.md
+++ b/catalog/UserConfidenceSoftwareUpdates.md
@@ -29,4 +29,4 @@ so that the latest application release is adopted.
 
 ### Acknowledgement
 
-This project tracking card was created using the [BSSw PSIP Project Tracking Card Catalog](https://bssw-psip.github.io/ptc-catalog/), part of the Exascale Computing Project (ECP).
+This Project Tracking Card originated from the [PSIP PTC Catalog](https://bssw-psip.github.io/ptc-catalog/). The development of the PSIP PTC Catalog was supported by the Exascale Computing Project (17-SC-20-SC), a collaborative effort of the U.S. Department of Energy Office of Science and the National Nuclear Security Administration.

--- a/catalog/UserConfidenceSoftwareUpdates.md
+++ b/catalog/UserConfidenceSoftwareUpdates.md
@@ -1,4 +1,4 @@
-[metadata:tags]:- "ecp-psip-ptc"
+[metadata:tags]:- "bssw-psip-ptc"
 # Promote User Confidence in Software Updates 
 
 ## Target

--- a/catalog/UserConfidenceSoftwareUpdates.md
+++ b/catalog/UserConfidenceSoftwareUpdates.md
@@ -1,4 +1,4 @@
-[_metadata_:tags]:- "psip-ptc"
+[_metadata_:tags]:- "ecp-psip-ptc"
 # Promote User Confidence in Software Updates 
 
 ## Target

--- a/catalog/UserConfidenceSoftwareUpdates.md
+++ b/catalog/UserConfidenceSoftwareUpdates.md
@@ -1,4 +1,4 @@
-[_metadata_:tags]:- "ecp-psip-ptc"
+[metadata:tags]:- "ecp-psip-ptc"
 # Promote User Confidence in Software Updates 
 
 ## Target
@@ -25,3 +25,8 @@ so that the latest application release is adopted.
 - Item 2: Can be implemented using Github issues, Jira or other means to be able to follow what each release includes. 
 - Item 3: See the [Performance Regression Testing card](https://github.com/bssw-psip/ptc-catalog/blob/master/catalog/PerformanceRegressionTesting.md)
 - Item 4: Could be something like turning a new feature on or off, setting a configuration variable to have a previous behavior, or a link to a prior release.
+
+
+### Acknowledgement
+
+This project tracking card was created using the [BSSw PSIP Project Tracking Card Catalog](https://bssw-psip.github.io/ptc-catalog/), part of the Exascale Computing Project (ECP).

--- a/catalog/UserConfidenceSoftwareUpdates.md
+++ b/catalog/UserConfidenceSoftwareUpdates.md
@@ -1,3 +1,4 @@
+[_metadata_:tags]:- "psip-ptc"
 # Promote User Confidence in Software Updates 
 
 ## Target

--- a/catalog/UserDocumentation.md
+++ b/catalog/UserDocumentation.md
@@ -36,4 +36,4 @@ introduction guide, software installation and initial setup testing guide, troub
 
 ### Acknowledgement
 
-This project tracking card was created using the [BSSw PSIP Project Tracking Card Catalog](https://bssw-psip.github.io/ptc-catalog/), part of the Exascale Computing Project (ECP).
+This Project Tracking Card originated from the [PSIP PTC Catalog](https://bssw-psip.github.io/ptc-catalog/). The development of the PSIP PTC Catalog was supported by the Exascale Computing Project (17-SC-20-SC), a collaborative effort of the U.S. Department of Energy Office of Science and the National Nuclear Security Administration.

--- a/catalog/UserDocumentation.md
+++ b/catalog/UserDocumentation.md
@@ -1,3 +1,4 @@
+[_metadata_:tags]:- "psip-ptc"
 # End-user Documentation
 
 ## Target

--- a/catalog/UserDocumentation.md
+++ b/catalog/UserDocumentation.md
@@ -1,4 +1,4 @@
-[metadata:tags]:- "ecp-psip-ptc"
+[metadata:tags]:- "bssw-psip-ptc"
 # End-user Documentation
 
 ## Target

--- a/catalog/UserDocumentation.md
+++ b/catalog/UserDocumentation.md
@@ -1,4 +1,4 @@
-[_metadata_:tags]:- "ecp-psip-ptc"
+[metadata:tags]:- "ecp-psip-ptc"
 # End-user Documentation
 
 ## Target
@@ -32,3 +32,8 @@ introduction guide, software installation and initial setup testing guide, troub
    - [ReadTheDocs](https://readthedocs.org)
    - [WriteTheDocs](https://www.writethedocs.org)
 
+
+
+### Acknowledgement
+
+This project tracking card was created using the [BSSw PSIP Project Tracking Card Catalog](https://bssw-psip.github.io/ptc-catalog/), part of the Exascale Computing Project (ECP).

--- a/catalog/UserDocumentation.md
+++ b/catalog/UserDocumentation.md
@@ -1,4 +1,4 @@
-[_metadata_:tags]:- "psip-ptc"
+[_metadata_:tags]:- "ecp-psip-ptc"
 # End-user Documentation
 
 ## Target


### PR DESCRIPTION
As part of the PSIP automation process, we want to add some metadata that can be traced (via github searches) when a project uses one of the catalog cards.

This PR recommends adding both metadata to the top (which will not render on GitHub or GitLab but will be in the raw source code) and an acknowledgement at the bottom. In this way, if a project is copy-pasting an existing PTC into their own repo, it should be searchable in two ways.

**NOTE**: The choice `ecp-psip-ptc` is for uniqueness. In searching all of GitHub, I didn't find a use of that tag or phrase anywhere that is unrelated to ECP.

EDIT: Partially resolves #41 