### PR TITLE
BUG FIX: Table of contents update script should ignore metadata line

### DIFF
--- a/update_toc.sh
+++ b/update_toc.sh
@@ -43,9 +43,9 @@ for card in `ls`; do
         echo "Processing $card"
         echo -n "| " >> $toc_loc
 
-        # format title (second line) into a markdown link
-        SECONDLINE=$(awk 'FNR==2' $card)
-        echo [${SECONDLINE:2}] >> $toc_loc
+        # format title into a markdown link
+        TITLE="$(sed -n 's/^# \(.*\)$/\1/p' $card | head -n 1)"
+        echo -n [${TITLE}] >> $toc_loc
         echo -n "($card)" >> $toc_loc
 
         echo -n " | " >> $toc_loc

--- a/update_toc.sh
+++ b/update_toc.sh
@@ -43,12 +43,13 @@ for card in `ls`; do
         echo "Processing $card"
         echo -n "| " >> $toc_loc
 
-        # format title (first line) into a markdown link
-        awk '{printf "[%s]", substr($0,3); exit}' $card >> $toc_loc
+        # format title (second line) into a markdown link
+        SECONDLINE=$(awk 'FNR==2' $card)
+        echo [${SECONDLINE:2}] >> $toc_loc
         echo -n "($card)" >> $toc_loc
 
         echo -n " | " >> $toc_loc
-        # print first non-zeno length line under "## Target" heading
+        # print first non-zero length line under "## Target" heading
         awk '/## Target/ {in_target=1; next}
              (length($0) > 1) && (in_target) { printf "%s", $0; exit}' $card >> $toc_loc
 


### PR DESCRIPTION
## BUG FIX

When I added the metadata tags, I didn't realize that it would cause the `update_toc.sh` script to render the titles incorrectly.

This fixes that issue.