### PR TITLE
Update CodingStandards.md

### DIFF
--- a/catalog/CodingStandards.md
+++ b/catalog/CodingStandards.md
@@ -22,7 +22,7 @@ As a software developer on a project that has a defined coding standard, I want 
 | 0 | No coding standard adopted. |
 | 1 | Team has come to agreement on coding standards and those standards are documented. |
 | 2 | New code that is written is required to comply with the standard, and the team has conducted a feedback session to assess and revise the standard.      |
-| 3 | The team has developed and put into place a refactoring plan to bring pre-existing code into compliance with the standard.      |
+| 3 | The team has developed and put into place a plan to bring pre-existing code into compliance with the standard.      |
 | 4 | Tool support has been put in place to help ensure compliance, and running the tool is made part of contribution guidelines.     |
 
 ### Variant B: What are the steps (tasks) I need to accomplish to achieve my goal?

--- a/catalog/CodingStandards.md
+++ b/catalog/CodingStandards.md
@@ -20,7 +20,7 @@ As a software developer on a project that has a defined coding standard, I want 
 | Stage         | Description |
 | :-------------: | :------------- |
 | 0 | No coding standard adopted. |
-| 1 | Team has selected an agreed-upon standard.      |
+| 1 | Team has come to agreement on coding standards and those standards are documented. |
 | 2 | New code that is written is required to comply with the standard, and the team has conducted a feedback session to assess and revise the standard.      |
 | 3 | The team has developed and put into place a refactoring plan to bring pre-existing code into compliance with the standard.      |
 | 4 | Tool support has been put in place to help ensure compliance, and running the tool is made part of contribution guidelines.     |


### PR DESCRIPTION
* I felt agreement alone was not sufficient to distinguish stage 1 from stage 2 here. What does *agreement* really mean? I think it means, minimally, that the coding standards everyone will adhere to are documented somewhere. It could also mean that new code written follows that standard which would result in a merging of stages 1 and 2. So, to keep those separate but nonetheless have stage 1 represent something a little more well defined and tangible value-added, I propose this change.
* I removed `refactoring` because I don't think actual refactoring of code is necessarily required to bring existing code into compliance with coding standards. It might be. But, I think its best to leave the "hows" out and be a little vague.